### PR TITLE
Print correct file name in "File not found" error messages.

### DIFF
--- a/esxplot/src/exp_myframe.py
+++ b/esxplot/src/exp_myframe.py
@@ -366,7 +366,7 @@ class MyFrame(esxp_gui.EsxPlotFrame):
             fpath = self.dirname+'/'+self.filename
 
             if os.path.exists(fpath) == False:
-                print("?File not found - "+sys.argv[1])
+                print("?File not found - " + fpath)
                 exit()
 
 
@@ -413,7 +413,7 @@ class MyFrame(esxp_gui.EsxPlotFrame):
             fpath = dirname + '/' + filename
 
             if os.path.exists(fpath) == False:
-                self.MyAlert("?File not found - " + sys.argv[1])
+                self.MyAlert("?File not found - " + fpath)
                 return
             f = open(fpath,"rb")
             rawqueries = f.readlines()        # read the entire query file


### PR DESCRIPTION
There were several references to sys.args[-1] when fpath was meant.
