### PR TITLE
Don't exit() if file to be imported can't be opened.

### DIFF
--- a/esxplot/src/exp_myframe.py
+++ b/esxplot/src/exp_myframe.py
@@ -367,7 +367,7 @@ class MyFrame(esxp_gui.EsxPlotFrame):
 
             if os.path.exists(fpath) == False:
                 print("?File not found - " + fpath)
-                exit()
+                return
 
 
             try:


### PR DESCRIPTION
just return and continue.
